### PR TITLE
Tests can now depend on the `build` target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.build
+
 test/*crate/Cargo.lock
 test/*crate/target
 test/zlibcrate/data.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,25 @@ SHELL := /bin/bash
 
 .PHONY: build run test push
 
-build:
+build: .build
+.build:
+	rm -f .build
 	docker build -t clux/muslrust .
+	touch .build
 push:
 	docker push clux/muslrust
 run:
 	docker run -v $$PWD/test:/volume  -w /volume -it clux/muslrust /bin/bash
 
-test-plain:
+test-plain: build
 	./test.sh plain
-test-curl:
+test-curl: build
 	./test.sh curl
-test-ssl:
+test-ssl: build
 	./test.sh ssl
-test-zlib:
+test-zlib: build
 	./test.sh zlib
 
 test: test-plain test-ssl test-curl test-zlib
+.PHONY: test-plain test-curl test-ssl test-zlib
+


### PR DESCRIPTION
This adds an extra (non-phony) target `.build` to flag if a docker image
has already been built.