### PR TITLE
Add NIGHTLY_SNAPSHOT build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,14 @@ RUN apt-get update && apt-get install -y \
   --no-install-recommends && \
   rm -rf /var/lib/apt/lists/*
 
-RUN curl https://static.rust-lang.org/rustup.sh | sh -s -- \
+ARG NIGHTLY_SNAPSHOT=""
+
+RUN if test "${NIGHTLY_SNAPSHOT}"; then DATEARG="--date=${NIGHTLY_SNAPSHOT}"; fi &&\
+  curl https://static.rust-lang.org/rustup.sh | sh -s -- \
   --with-target=x86_64-unknown-linux-musl \
   --yes \
   --disable-sudo \
+  ${DATEARG} \
   --channel=nightly && \
   mkdir /.cargo && \
   echo "[build]\ntarget = \"x86_64-unknown-linux-musl\"" > /.cargo/config


### PR DESCRIPTION
This is a build argument that you can pass in the `docker build`
command. With this you can pin the Rust nightly version to a snapshot (i.e.
`--build-arg NIGHTLY_SNAPSHOT=2017-06-13` for rust-nightly-2017-06-13).

The default behavior is unaffected, it will build with the latest like normal.