### PR TITLE
attemps at libpq - resumed from #17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get install -y \
   --no-install-recommends && \
   rm -rf /var/lib/apt/lists/*
 
+# Install rust
 ARG NIGHTLY_SNAPSHOT=""
-
 RUN if test "${NIGHTLY_SNAPSHOT}"; then DATEARG="--date=${NIGHTLY_SNAPSHOT}"; fi &&\
   curl https://static.rust-lang.org/rustup.sh | sh -s -- \
   --with-target=x86_64-unknown-linux-musl \
@@ -33,19 +33,29 @@ RUN if test "${NIGHTLY_SNAPSHOT}"; then DATEARG="--date=${NIGHTLY_SNAPSHOT}"; fi
 
 # Compile C libraries with musl-gcc
 ENV SSL_VER=1.0.2l \
-    CURL_VER=7.55.1 \
-    POSTGRESQL_VER=9.6.5 \
+    CURL_VER=7.56.0 \
+    ZLIB_VER=1.2.11 \
+    PQ_VER=9.6.5 \
     CC=musl-gcc \
     PREFIX=/usr/local \
     PATH=/usr/local/bin:$PATH \
     PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
+# Build zlib (used in openssl and pq)
+RUN curl -sSL http://zlib.net/zlib-$ZLIB_VER.tar.gz | tar xz && \
+    cd zlib-$ZLIB_VER && \
+    CC="musl-gcc -fPIC" ./configure --static --prefix=$PREFIX && \
+    make -j$(nproc) && make install && \
+    cd .. && rm -rf zlib-$ZLIB_VER
+
+# Build openssl (used in curl and pq)
 RUN curl -sL http://www.openssl.org/source/openssl-$SSL_VER.tar.gz | tar xz && \
     cd openssl-$SSL_VER && \
-    ./Configure no-shared --prefix=$PREFIX --openssldir=$PREFIX/ssl no-zlib linux-x86_64 -fPIC && \
-    make depend 2> /dev/null && make -j$(nproc) && make install && \
+    env CC="musl-gcc -fPIC" ./Configure no-shared --prefix=$PREFIX --openssldir=$PREFIX/ssl linux-x86_64 -fPIC && \
+    env C_INCLUDE_PATH=$PREFIX/musl/include make depend 2> /dev/null && make -j$(nproc) && make install && \
     cd .. && rm -rf openssl-$SSL_VER
 
+# Build curl
 RUN curl https://curl.haxx.se/download/curl-$CURL_VER.tar.gz | tar xz && \
     cd curl-$CURL_VER && \
     ./configure --enable-shared=no --enable-static=ssl --enable-optimize --prefix=$PREFIX \
@@ -53,13 +63,20 @@ RUN curl https://curl.haxx.se/download/curl-$CURL_VER.tar.gz | tar xz && \
     make -j$(nproc) && make install && \
     cd .. && rm -rf curl-$CURL_VER
 
-ENV PKG_CONFIG_ALL_STATIC=1 \
-    PQ_LIB_STATIC=1
-RUN curl https://ftp.postgresql.org/pub/source/v$POSTGRESQL_VER/postgresql-$POSTGRESQL_VER.tar.bz2 | tar xj && \
-    cd postgresql-$POSTGRESQL_VER && \
-    ./configure --with-openssl --without-readline --without-zlib --prefix=$PREFIX --with-libs=$PREFIX/lib --with-includes=$PREFIX/include && \
-    make && make install && \
-    cd .. && rm -rf postgresql-$POSTGRESQL_VER
+# Build libpq
+RUN curl -sSL https://ftp.postgresql.org/pub/source/v$PQ_VER/postgresql-$PQ_VER.tar.gz | tar xz && \
+    cd postgresql-$PQ_VER && \
+    CC="musl-gcc -fPIE -pie" LDFLAGS="-L$PREFIX/lib" CFLAGS="-I$PREFIX/include" ./configure \
+    --without-readline --with-openssl --with-zlib \
+    --prefix=$PREFIX --host=x86_64-unknown-linux-musl && \
+    cd src/interfaces/libpq && \
+    make -j$(nproc) all-static-lib && make install-lib-static && \
+    cd ../../../.. && rm -rf postgresql-$PQ_VER
+
+# Some extra evars for pq-sys
+ENV PQ_LIB_STATIC=1 \
+    PQ_LIB_DIR=$PREFIX/lib \
+    PKG_CONFIG_ALL_STATIC=1
 
 # SSL cert directories get overridden by --prefix and --openssldir
 # and they do not match the typical host configurations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN if test "${NIGHTLY_SNAPSHOT}"; then DATEARG="--date=${NIGHTLY_SNAPSHOT}"; fi
 # Compile C libraries with musl-gcc
 ENV SSL_VER=1.0.2l \
     CURL_VER=7.55.1 \
+    POSTGRESQL_VER=9.6.5 \
     CC=musl-gcc \
     PREFIX=/usr/local \
     PATH=/usr/local/bin:$PATH \
@@ -51,6 +52,14 @@ RUN curl https://curl.haxx.se/download/curl-$CURL_VER.tar.gz | tar xz && \
       --with-ca-path=/etc/ssl/certs/ --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt --without-ca-fallback && \
     make -j$(nproc) && make install && \
     cd .. && rm -rf curl-$CURL_VER
+
+ENV PKG_CONFIG_ALL_STATIC=1 \
+    PQ_LIB_STATIC=1
+RUN curl https://ftp.postgresql.org/pub/source/v$POSTGRESQL_VER/postgresql-$POSTGRESQL_VER.tar.bz2 | tar xj && \
+    cd postgresql-$POSTGRESQL_VER && \
+    ./configure --with-openssl --without-readline --without-zlib --prefix=$PREFIX --with-libs=$PREFIX/lib --with-includes=$PREFIX/include && \
+    make && make install && \
+    cd .. && rm -rf postgresql-$POSTGRESQL_VER
 
 # SSL cert directories get overridden by --prefix and --openssldir
 # and they do not match the typical host configurations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y \
   g++ \
   python \
   make \
-  nano \
   ca-certificates \
   xz-utils \
   musl-tools \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ test-plain:
 	./test.sh plain
 test-curl:
 	./test.sh curl
+test-pq:
+	./test.sh pq
 test-ssl:
 	./test.sh ssl
 test-zlib:
@@ -26,6 +28,6 @@ clean-builds:
 	sudo find . -mindepth 3 -maxdepth 3 -name target -exec rm -rf {} \;
 clean: clean-docker clean-lock clean-builds
 
-test: test-plain test-ssl test-curl test-zlib test-hyper
-.PHONY: test-plain test-curl test-ssl test-zlib test-hyper
+test: test-plain test-ssl test-pq test-curl test-zlib test-hyper
+.PHONY: test-plain test-ssl test-pq test-curl test-zlib test-hyper
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following system libraries are compiled against `musl-gcc`:
 
 - [x] curl ([curl crate](https://github.com/carllerche/curl-rust))
 - [x] openssl ([openssl crate](https://github.com/sfackler/rust-openssl))
+- [x] pq ([pq crate](https://github.com/sgrif/pq-sys) used by [diesel](https://github.com/diesel-rs/diesel))
 
 We try to keep these up to date.
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ The following system libraries are compiled against `musl-gcc`:
 - [x] curl ([curl crate](https://github.com/carllerche/curl-rust))
 - [x] openssl ([openssl crate](https://github.com/sfackler/rust-openssl))
 - [x] pq ([pq crate](https://github.com/sgrif/pq-sys) used by [diesel](https://github.com/diesel-rs/diesel))
+- [x] zlib (used by pq and openssl)
 
 We try to keep these up to date.
 
-zlib is not included as the common `flate2` crate bundles `miniz.c` as the default implementation, and this just works.
+If it weren't for pq, we could ditch zlib as the `flate2` crate bundles `miniz.c` as the default implementation, and this just works. Similarly, curl is only needed for people using the C bindings to curl over [hyper](https://hyper.rs/).
 
 ## Developing
 Clone, tweak, build, and run tests:
@@ -64,6 +65,11 @@ export SSL_CERT_DIR=/etc/ssl/certs
 ```
 
 You can also hardcode this in your binary, or, more sensibly set it in your running docker image.
+
+## Diesel and PQ builds
+Currently experimental. Core `diesel` should work, but `diesel_codegen` currently fails to link.
+
+For stuff like `infer_schema!` to work you need to explicitly pass on `-e DATABASE_URL=$DATABASE_URL` to the `docker run`.
 
 ## Caching Cargo Locally
 Repeat builds locally are always from scratch (thus slow) without a cached cargo directory. You can set up a docker volume by just adding `-v cargo-cache:/root/.cargo` to the docker run command.

--- a/test.sh
+++ b/test.sh
@@ -6,13 +6,14 @@ docker_build() {
   docker run \
     --rm \
     -v "$PWD/test/${crate}:/volume" \
+    -v cargo-cache:/root/.cargo \
     -w /volume \
     -e RUST_BACKTRACE=1 \
-    -t clux/muslrust \
-    cargo build --verbose
+    -it clux/muslrust \
+    cargo build -vv
   cd "test/${crate}"
   ./target/x86_64-unknown-linux-musl/debug/"${crate}"
-  [[ "$(ldd target/x86_64-unknown-linux-musl/debug/${crate})" =~ "not a dynamic" ]] && \
+  [[ "$(ldd "target/x86_64-unknown-linux-musl/debug/${crate}")" =~ "not a dynamic" ]] && \
     echo "${crate} is a static executable"
 }
 

--- a/test/pqcrate/Cargo.toml
+++ b/test/pqcrate/Cargo.toml
@@ -5,3 +5,4 @@ version = "0.1.0"
 
 [dependencies]
 pq-sys = "0.4.4"
+openssl = "*"

--- a/test/pqcrate/Cargo.toml
+++ b/test/pqcrate/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+authors = ["clux <sszynrae@gmail.com>"]
+name = "pqcrate"
+version = "0.1.0"
+
+[dependencies]
+pq-sys = "0.4.4"

--- a/test/pqcrate/src/main.rs
+++ b/test/pqcrate/src/main.rs
@@ -1,0 +1,5 @@
+extern crate pq_sys;
+
+fn main() {
+    unsafe{ pq_sys::PQinitSSL(1); }
+}

--- a/test/pqcrate/src/main.rs
+++ b/test/pqcrate/src/main.rs
@@ -1,4 +1,5 @@
 extern crate pq_sys;
+extern crate openssl; // needed to avoid link errors even if we don't use it directly
 
 fn main() {
     unsafe{ pq_sys::PQinitSSL(1); }


### PR DESCRIPTION
before setting the PQ_LIB_STATIC, we would still try to dynamically link with libpq, now it at least tries, but the test crate fails with a link error. It's a start.