### PR TITLE
Unblock rocket + docs tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,6 @@ clean-builds:
 	sudo rm -f test/dieselsqlitecrate/main.db
 clean: clean-docker clean-lock clean-builds
 
-test: test-plain test-ssl test-pq test-rocket test-serde test-curl test-zlib test-hyper test-dieselpg test-dieselsqlite
+test: test-plain test-ssl test-pq test-serde test-curl test-zlib test-hyper test-dieselpg test-dieselsqlite
 .PHONY: test-plain test-ssl test-pq test-rocket test-serde test-curl test-zlib test-hyper test-dieselpg test-dieselsqlite
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean-lock:
 	sudo find . -iname Cargo.lock -exec rm {} \;
 clean-builds:
 	sudo find . -mindepth 3 -maxdepth 3 -name target -exec rm -rf {} \;
-	rm test/dieselsqlitecrate/main.db
+	sudo rm -f test/dieselsqlitecrate/main.db
 clean: clean-docker clean-lock clean-builds
 
 test: test-plain test-ssl test-pq test-rocket test-serde test-curl test-zlib test-hyper test-dieselpg test-dieselsqlite

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ We try to keep these up to date.
 
 If it weren't for pq, we could ditch zlib as the `flate2` crate bundles `miniz.c` as the default implementation, and this just works. Similarly, curl is only needed for people using the C bindings to curl over [hyper](https://hyper.rs/).
 
+If you need extra dependencies, you can follow the builder pattern approach by [portier-broker](https://github.com/portier/portier-broker/blob/master/Dockerfile)
+
 ## Developing
 Clone, tweak, build, and run tests:
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ make test
 Before we push a new version of muslrust we ensure that we can use and statically link:
 
 - [x] `serde`
-- [x] `rocket`
 - [x] `diesel` (postgres and sqlite - see note below for postgres)
 - [x] `hyper`
 - [x] `curl`
 - [x] `openssl`
 - [x] `flate2`
 - [x] `rand`
+- [ ] `rocket` (nightly only - [occasionally breaks](https://github.com/clux/muslrust/issues/32))
 
 ## SSL Verification
 You need to point openssl at the location of your certificates explicitly to have https requests not return certificate errors.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ The following system libraries are compiled against `musl-gcc`:
 
 - [x] curl ([curl crate](https://github.com/carllerche/curl-rust))
 - [x] openssl ([openssl crate](https://github.com/sfackler/rust-openssl))
-- [x] pq ([pq crate](https://github.com/sgrif/pq-sys) used by [diesel](https://github.com/diesel-rs/diesel))
+- [x] pq ([pq-sys crate](https://github.com/sgrif/pq-sys) used by [diesel](https://github.com/diesel-rs/diesel))
+- [x] sqlite3 ([libsqlite3-sys crate](https://github.com/jgallagher/rusqlite/tree/master/libsqlite3-sys) used by [diesel](https://github.com/diesel-rs/diesel))
 - [x] zlib (used by pq and openssl)
 
 We try to keep these up to date.
@@ -58,7 +59,7 @@ Before we push a new version of muslrust we ensure that we can use and staticall
 
 - [x] `serde`
 - [x] `rocket`
-- [x] `diesel` (needs a fork of pq-sys currently)
+- [x] `diesel` (postgres and sqlite - see note below for postgres)
 - [x] `hyper`
 - [x] `curl`
 - [x] `openssl`


### PR DESCRIPTION
Basically to allow continued building despite #32 

Maybe there's a better solution, but would rather keep producing perfectly valid nighties with at least the guarantee that the normal stable modules work on them for now. Can always re-add rocket back if it becomes more stable.