### PR TITLE
Update libraries automatically from Arch Linux repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,11 @@ RUN if test "${NIGHTLY_SNAPSHOT}"; then DATEARG="--date=${NIGHTLY_SNAPSHOT}"; fi
 
 # Convenience list of versions and variables for compilation later on
 # This helps continuing manually if anything breaks.
-ENV SSL_VER=1.0.2n \
-    CURL_VER=7.58.0 \
-    ZLIB_VER=1.2.11 \
-    PQ_VER=9.6.8 \
-    SQLITE_VER=3220000 \
+ENV SSL_VER="1.0.2o" \
+    CURL_VER="7.60.0" \
+    ZLIB_VER="1.2.11" \
+    PQ_VER="9.6.9" \
+    SQLITE_VER="3240000" \
     CC=musl-gcc \
     PREFIX=/musl \
     PATH=/usr/local/bin:$PATH \

--- a/update_libs.py
+++ b/update_libs.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# update_libs.py
+#
+# Retrieve the versions of packages from Arch Linux's repositories and update
+# Dockerfile as needed.
+#
+# The code in documentation comments can also be used to test the functions by
+# running "python -m doctest update_libs.py -v".
+
+from __future__ import print_function
+
+try:
+    # Python 3
+    import urllib.request as urllib
+except ImportError:
+    # Python 2
+    import urllib
+
+import json
+import os
+import re
+
+
+def convert_openssl_version(version):
+    """ Convert OpenSSL package versions to match upstream's format
+
+    >>> convert_openssl_version('1.0.2.o')
+    '1.0.2o'
+    """
+
+    return re.sub(r'(.+)\.([a-z])', r'\1\2', version)
+
+
+def convert_sqlite_version(version):
+    """Convert SQLite package versions to match upstream's format
+
+    >>> convert_sqlite_version('3.24.0')
+    '3240000'
+    """
+
+    matches = re.match(r'(\d+)\.(\d+)\.(\d+)', version)
+    return '{:d}{:02d}{:02d}00'.format(int(matches.group(1)), int(matches.group(2)), int(matches.group(3)))
+
+
+def pkgver(package):
+    """Retrieve the current version of the package in Arch Linux repos
+
+    API documentation: https://wiki.archlinux.org/index.php/Official_repositories_web_interface
+
+    The "str" call is only needed to make the test pass on Python 2 and 3, you
+    do not need to include it when using this function.
+
+    >>> str(pkgver('reiserfsprogs'))
+    '3.6.27'
+    """
+
+    # Though the URL contains "/search/", this only returns exact matches (see API documentation)
+    url = 'https://www.archlinux.org/packages/search/json/?name={}'.format(package)
+    req = urllib.urlopen(url)
+    metadata = json.loads(req.read())
+    req.close()
+    try:
+        return metadata['results'][0]['pkgver']
+    except IndexError:
+        raise NameError('Package not found: {}'.format(package))
+
+
+if __name__ == '__main__':
+    PACKAGES = {
+        'CURL': pkgver('curl'),
+        'PQ': pkgver('postgresql-old-upgrade'),
+        'SQLITE': convert_sqlite_version(pkgver('sqlite')),
+        'SSL': convert_openssl_version(pkgver('openssl-1.0')),
+        'ZLIB': pkgver('zlib'),
+    }
+
+    # Show a list of packages with current versions
+    for prefix in PACKAGES:
+        print('{}_VER="{}"'.format(prefix, PACKAGES[prefix]))
+
+    # Open a different file for the destination to update Dockerfile atomically
+    src = open('Dockerfile', 'r')
+    dst = open('Dockerfile.new', 'w')
+
+    # Iterate over each line in Dockerfile, replacing any *_VER variables with the most recent version
+    for line in src:
+        for prefix in PACKAGES:
+            version = PACKAGES[prefix]
+            line = re.sub(r'({}_VER=)\S+'.format(prefix), r'\1"{}"'.format(version), line)
+        dst.write(line)
+
+    # Close original and new Dockerfile then overwrite the old with the new
+    src.close()
+    dst.close()
+    os.rename('Dockerfile.new', 'Dockerfile')

--- a/update_libs.py
+++ b/update_libs.py
@@ -22,7 +22,7 @@ import re
 
 
 def convert_openssl_version(version):
-    """ Convert OpenSSL package versions to match upstream's format
+    """Convert OpenSSL package versions to match upstream's format
 
     >>> convert_openssl_version('1.0.2.o')
     '1.0.2o'


### PR DESCRIPTION
This implements #38, pulling the latest version of packages from Arch repos using their API and updating Dockerfile as needed using a fairly short and simple Python script with comments and tests.

Two packages have their versions modified from the original `pkgver`:
- `openssl-1.0`: Arch's packages add a period between the final digit and the letter in the version.
- `sqlite`: Download URLs for SQLite use a zero-padded string of numbers with no periods.

A second commit was added after running said script, updating the libraries.