### PR TITLE
Don't rely on CircleCI's native git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y \
   musl-tools \
   file \
   git \
+  openssh-client \
   make \
   g++ \
   curl \


### PR DESCRIPTION
Solves:
"Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed."