### PR TITLE
Pin nightly to a date instead of using "nightly" as the toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ services:
 - docker
 script:
 - export RUST_CHANNEL="nightly"
+- export RUST_DATE=$(date +"%Y-%m-%d")
 - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
   fi
-- docker build --build-arg CHANNEL=${RUST_CHANNEL} -t clux/muslrust .
-- export RUST_DATE=$(docker run -it clux/muslrust rustc --version | grep -oE "[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}")
+- docker build --build-arg CHANNEL="${RUST_CHANNEL}-${RUST_DATE}" -t clux/muslrust .
 - export RUST_VER=$(docker run -it clux/muslrust rustc --version | grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]")
 - export TAG1="${RUST_VER}-${RUST_CHANNEL}"
 - export TAG2="${RUST_CHANNEL}-${RUST_DATE}"


### PR DESCRIPTION
Similar to #14, but for perhaps different reasons.

Using an unpinned nightly means that when this docker container is used to build another one (adding in special libraries and tools for a project's build container), it may fail when using rustup to download a component. Even if the component is available for the nightly that the docker container was built with, it will fail because it is looking for "nightly"'s version of the component instead of "nightly-XXX-XX-XX"'s version.

Example: Right now (2019-10-16) clippy is missing in nightly, but was there yesterday:
https://rust-lang.github.io/rustup-components-history/index.html
If the container for `nightly-2019-10-15` is used, it will fail to download clippy even though it exists for the nightly the container was built with.
```
$ docker run --rm -it clux/muslrust:nightly-2019-10-15 /bin/bash
# rustup toolchain list
nightly-x86_64-unknown-linux-gnu (default)
# rustc --version
rustc 1.40.0-nightly (237d54ff6 2019-10-15)
# rustup component add clippy
error: component 'clippy' for target 'x86_64-unknown-linux-gnu' is unavailable for download for channel nightly
```

This change assumes that the nightly's date is the same as the current date. If it turns out the it's one less, more modifications can be made to support that.