### PR TITLE
Install the minimal rustup profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y \
 # Install rust using rustup
 ARG CHANNEL="nightly"
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- -y --default-toolchain ${CHANNEL} && \
+    sh -s -- -y --default-toolchain ${CHANNEL} --profile minimal && \
     ~/.cargo/bin/rustup target add x86_64-unknown-linux-musl && \
     echo "[build]\ntarget = \"x86_64-unknown-linux-musl\"" > ~/.cargo/config
 


### PR DESCRIPTION
[Rustup 1.12.0] introduced profiles and changed the default installation to include more components. Now, rustfmt and clippy are included by default in the "default" profile. A new "minimal" profile is also
available and should be used in CI from now on. Compared to the previous default install, it is lighter as it does not include rust-docs.

The difference in default components can be seen in recent CI runs, one before and one after the new rustup release:
2019-10-11: https://travis-ci.org/clux/muslrust/builds/596639602#L797-L800
2019-10-15: https://travis-ci.org/clux/muslrust/builds/598191165#L798-L803

[Rustup 1.12.0]: https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html