### PR TITLE
silence tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer="Eirik Albrigtsen <sszynrae@gmail.com>"
 # - automake autoconf libtool - support crates building C deps as part cargo build
 # recently removed:
 # cmake (not used), nano, zlib1g-dev
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
   musl-dev \
   musl-tools \
   file \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainer="Eirik Albrigtsen <sszynrae@gmail.com>"
 # - automake autoconf libtool - support crates building C deps as part cargo build
 # recently removed:
 # cmake (not used), nano, zlib1g-dev
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
+RUN apt-get update && apt-get install -y \
   musl-dev \
   musl-tools \
   file \
@@ -136,7 +136,9 @@ ENV PATH=$PREFIX/bin:$PATH \
     OPENSSL_DIR=$PREFIX \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
     SSL_CERT_DIR=/etc/ssl/certs \
-    LIBZ_SYS_STATIC=1
+    LIBZ_SYS_STATIC=1 \
+    DEBIAN_FRONTEND=noninteractive \
+    TZ=Etc/UTC
 
 # Allow ditching the -w /volume flag to docker run
 WORKDIR /volume


### PR DESCRIPTION
After the recent update to jammy, `apt-get install` has started prompting an interactive while trying to configure tzdata.
```
Please select the geographic area in which you live. Subsequent configuration questions will narrow this down by presenting a list of cities, representing the time zones in which they are located.

  1. Africa  2. America  3. Antarctica  4. Australia  5. Arctic  6. Asia  7. Atlantic  8. Europe  9. Indian  10. Pacific  11. US  12. Etc
  ```
  
  This silences the prompt and sets the timezone to UTC by default
  
  
  **Steps to reproduce:**
  1. docker run -it clux/muslrust
  2. apt-get update && apt-get install -y awscli
  