### PR TITLE
libpg 12+ working branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,13 +1,4 @@
 name: nightly
-on:
-  schedule:
-    - cron: '0 10 * * *' # everyday at 10am
-  push:
-    branches:
-      - 'main'
-  pull_request:
-    branches:
-      - 'main'
 
 jobs:
   docker:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,13 +1,4 @@
 name: stable
-on:
-  schedule:
-    - cron: '0 12 * * *' # everyday at noon
-  push:
-    branches:
-      - 'main'
-  pull_request:
-    branches:
-      - 'main'
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY etc/profile.d/cargo.sh /etc/profile.d/cargo.sh
 ENV SSL_VER="1.1.1o" \
     CURL_VER="7.83.1" \
     ZLIB_VER="1.2.12" \
-    PQ_VER="11.12" \
+    PQ_VER="14.3" \
     SQLITE_VER="3380500" \
     CC=musl-gcc \
     PREFIX=/musl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,8 @@ RUN curl -sSL https://ftp.postgresql.org/pub/source/v$PQ_VER/postgresql-$PQ_VER.
     --without-readline \
     --with-openssl \
     --prefix=$PREFIX --host=x86_64-unknown-linux-musl && \
+    cd src/common && make -s -j$(nproc) all && make -s install && cd ../.. && \
+    cd src/port && make -s -j$(nproc) all && make -s install && cd ../.. && \
     cd src/interfaces/libpq make -s -j$(nproc) all-static-lib && make -s install install-lib-static && \
     cd ../../bin/pg_config && make -j $(nproc) && make install && \
     cd .. && rm -rf postgresql-$PQ_VER
@@ -126,11 +128,15 @@ RUN curl -sSL https://www.sqlite.org/2022/sqlite-autoconf-$SQLITE_VER.tar.gz | t
 # It needs the non-musl pg_config to set this up with libpq-dev (depending on libssl-dev)
 # See https://github.com/sgrif/pq-sys/pull/18
 ENV PATH=$PREFIX/bin:$PATH \
+    TARGET=x86_64_unknown_linux_musl \
+    HOST=x86_64_unknown_linux_gnu \
     PKG_CONFIG_ALLOW_CROSS=true \
     PKG_CONFIG_ALL_STATIC=true \
     PQ_LIB_STATIC_X86_64_UNKNOWN_LINUX_MUSL=true \
     PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig \
+    PKG_CONFIG_PATH_X86_64_UNKNOWN_LINUX_MUSL=$PREFIX/lib/pkgconfig \
     PG_CONFIG_X86_64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
+    PG_CONFIG_X86_64_UNKNOWN_LINUX_MUSL=/musl/bin/pg_config \
     OPENSSL_STATIC=true \
     OPENSSL_DIR=$PREFIX \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \

--- a/test/pqcrate/Cargo.toml
+++ b/test/pqcrate/Cargo.toml
@@ -4,5 +4,6 @@ name = "pqcrate"
 version = "0.1.0"
 
 [dependencies]
-pq-sys = "0.4.5"
+#pq-sys = "0.4.5"
+pq-sys = { git = "https://github.com/golddranks/pq-sys.git", rev = "8bc178b2a3859704585f4d4b39d2942c040e350b" }
 openssl = "*"

--- a/update_libs.py
+++ b/update_libs.py
@@ -83,7 +83,7 @@ def rustup_version():
 if __name__ == '__main__':
     PACKAGES = {
         'CURL': pkgver('curl'),
-        #'PQ': pkgver('postgresql-old-upgrade'), # see https://github.com/clux/muslrust/issues/81
+        'PQ': pkgver('postgresql'),
         'SQLITE': convert_sqlite_version(pkgver('sqlite')),
         'SSL': convert_openssl_version(pkgver('openssl')),
         'ZLIB': pkgver('zlib'),


### PR DESCRIPTION
need to link `libpgport` and `libpgcommon` [since libpg12](https://www.postgresql.org/message-id/CACS8yHL0gbL3ECONrDygcBioTQBY%3DoVG-KGWB6%2BN7spG%2BeSMQw%40mail.gmail.com)

manually compiling in two extra pg libraries in the stable image on this branch:

- [x] [`libpgcommon` is found in src/common](https://pgpedia.info/l/libpgcommon.html)
- [x] [`libpgport` is found in src/port](https://git.postgresql.org/gitweb/?p=postgresql.git;a=tree;f=src/port;hb=HEAD)

and also using  the link flags from an ancient pr: https://github.com/sgrif/pq-sys/pull/28/files for https://github.com/sgrif/pq-sys/issues/27 but that's been ignored for 2 years...