### PR TITLE
fix: Unify `root` and non-root user behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,14 +38,12 @@ ENV RUSTUP_VER="1.24.3" \
     RUST_ARCH="x86_64-unknown-linux-gnu"
 RUN curl "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/${RUST_ARCH}/rustup-init" -o rustup-init && \
     chmod +x rustup-init && \
-    ./rustup-init -y --default-toolchain ${CHANNEL} --profile minimal && \
+    ./rustup-init -y --default-toolchain ${CHANNEL} --profile minimal --no-modify-path && \
     rm rustup-init && \
-    ~/.cargo/bin/rustup target add x86_64-unknown-linux-musl && \
-    echo "[build]\ntarget = \"x86_64-unknown-linux-musl\"" > ~/.cargo/config
+    ~/.cargo/bin/rustup target add x86_64-unknown-linux-musl
 
 # Allow non-root access to cargo
 RUN chmod a+X /root
-COPY etc/profile.d/cargo.sh /etc/profile.d/cargo.sh
 
 # Convenience list of versions and variables for compilation later on
 # This helps continuing manually if anything breaks.
@@ -125,7 +123,9 @@ RUN curl -sSL https://www.sqlite.org/2022/sqlite-autoconf-$SQLITE_VER.tar.gz | t
 # but finally links with the static libpq.a at the end.
 # It needs the non-musl pg_config to set this up with libpq-dev (depending on libssl-dev)
 # See https://github.com/sgrif/pq-sys/pull/18
-ENV PATH=$PREFIX/bin:$PATH \
+ENV PATH=/root/.cargo/bin:$PREFIX/bin:$PATH \
+    RUSTUP_HOME=/root/.rustup \
+	CARGO_BUILD_TARGET=x86_64-unknown-linux-musl \
     PKG_CONFIG_ALLOW_CROSS=true \
     PKG_CONFIG_ALL_STATIC=true \
     PQ_LIB_STATIC_X86_64_UNKNOWN_LINUX_MUSL=true \

--- a/etc/profile.d/cargo.sh
+++ b/etc/profile.d/cargo.sh
@@ -1,4 +1,0 @@
-if command -v cargo 2>/dev/null; then
-    export PATH=/root/.cargo/bin:$PATH
-    export RUSTUP_HOME=/root/.rustup
-fi


### PR DESCRIPTION
This makes building as `root` and as a non-root user behave the same.

Before, building as a non-root user (i.e., via `podman run --userns=keep-id`) would be different in the following ways:

- It would not automatically source `/etc/profile.d/cargo.sh` (at least for me)
- As a result, `RUSTUP_HOME` would not be set and cargo would complain about not having a default target
- It would not build against the `x86_64-unknown-linux-musl` target because [cargo's default config location is `~/.cargo/config`](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure), but we only write our desired build target into `~root/.cargo/config`, which is not checked when a non-root user invokes cargo

This PR fixes all that by configuring all those settings as environment variables instead. It also sets the cargo `PATH` via an environment variable, so `/etc/profile.d/cargo.sh` is not needed anymore.

A downside of this approach is that the build target triple cannot be overridden via config files because the `CARGO_BUILD_TARGET` environment variable has higher precedence than a `~/.cargo/config` entry. I figured this would be fine since the entire _point_ of this project is to build against that specific target triple. :upside_down_face: 