### PR TITLE
feat: install protobuf-compiler to add protoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
   automake \
   autoconf \
   libtool \
+  protobuf-compiler \
   --no-install-recommends && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
tonic-build require protoc cli tool to generate the codes, install
protobuf-compiler allow user can use this image to build tonic codes
directly

Signed-off-by: Sherlock Holo <sherlockya@gmail.com>