### PR TITLE
Use docker registry API v2

### DIFF
--- a/check_stable.py
+++ b/check_stable.py
@@ -25,11 +25,12 @@ def rust_stable_version():
 
 def tag_exists(tag):
     """Retrieve our built tags and check we have built a given one"""
-    url = f'https://registry.hub.docker.com/v1/repositories/{DOCKERHUB_REPO}/tags'
+    (namespace, repo) = DOCKERHUB_REPO.split("/")
+    url = f'https://registry.hub.docker.com/v2/namespaces/{namespace}/repositories/{repo}/tags'
     req = urllib.urlopen(url)
     data = json.loads(req.read())
     req.close()
-    for x in data:
+    for x in data['results']:
         if x['name'] == tag:
             return True
     return False


### PR DESCRIPTION
Update to use v2 of the docker registry API instead of the now deprecated v1 in `check_stable.py`.

The presently used v1 API now returns 410 errors, e.g. https://registry.hub.docker.com/v1/repositories/clux/muslrust/tags
These errors are silently failing in the github actions: https://github.com/clux/muslrust/actions/runs/3197211305/jobs/5220130053#step:4:36