### PR TITLE
chore: add cmake to support rdkafka

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
   git \
   openssh-client \
   make \
+  cmake \
   g++ \
   curl \
   pkgconf \


### PR DESCRIPTION
To build rdkafka with musl `cmake` must be installed.

closes https://github.com/clux/muslrust/issues/109