### PR TITLE
install protobuf compiler from releases instead of apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,17 @@ RUN apt-get update && apt-get install -y \
   automake \
   autoconf \
   libtool \
-  protobuf-compiler \
   libprotobuf-dev \
+  unzip \
   --no-install-recommends && \
   rm -rf /var/lib/apt/lists/*
+
+# Install a more recent release of protoc (protobuf-compiler in jammy is 4 years old and misses some features)
+RUN cd /tmp && \
+    curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip -o protoc.zip && \
+    unzip protoc.zip && \
+    cp bin/protoc /usr/bin/protoc && \
+    rm -rf *
 
 # Install rust using rustup
 ARG CHANNEL

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install a more recent release of protoc (protobuf-compiler in jammy is 4 years old and misses some features)
 RUN cd /tmp && \
-    curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip -o protoc.zip && \
+    curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-linux-x86_64.zip -o protoc.zip && \
     unzip protoc.zip && \
     cp bin/protoc /usr/bin/protoc && \
     rm -rf *

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install -y \
   rm -rf /var/lib/apt/lists/*
 
 # Install a more recent release of protoc (protobuf-compiler in jammy is 4 years old and misses some features)
+ENV PROTOC_VER="25.2"
 RUN cd /tmp && \
     curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-linux-x86_64.zip -o protoc.zip && \
     unzip protoc.zip && \


### PR DESCRIPTION
Hi, would you take a PR to uprev protobuf?

This gets to 1.25, from 1.12 which is 4 years old

Thanks for your work