### PR TITLE
add missing tags

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -153,7 +153,7 @@ jobs:
           RUST_CHANNEL=$(cat /tmp/tags/rust-channel)
           RUST_VER=$(cat /tmp/tags/rust-ver)
 
-          for tag in latest ${RUST_CHANNEL} ${RUST_CHANNEL}-${RUST_DATE} ${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}; do
+          for tag in latest ${RUST_CHANNEL} ${RUST_CHANNEL}-${RUST_DATE} ${RUST_VER}-${RUST_CHANNEL} ${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}; do
             docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:$tag \
               ${{ env.REGISTRY_IMAGE }}:amd64-${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE} \
               ${{ env.REGISTRY_IMAGE }}:arm64-${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -185,7 +185,7 @@ jobs:
         RUST_CHANNEL=$(cat /tmp/tags/rust-channel)
         RUST_VER=$(cat /tmp/tags/rust-ver)
 
-        for tag in ${RUST_CHANNEL} ${RUST_CHANNEL}-${RUST_DATE} ${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}; do
+        for tag in ${RUST_CHANNEL} ${RUST_CHANNEL}-${RUST_DATE} ${RUST_VER}-${RUST_CHANNEL} ${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}; do
           docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:$tag \
             ${{ env.REGISTRY_IMAGE }}:amd64-${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE} \
             ${{ env.REGISTRY_IMAGE }}:arm64-${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}


### PR DESCRIPTION
I noticed `stable` got released to docker again today and upon further investigation it looks like [this](https://github.com/clux/muslrust/blob/main/check_stable.py#L41) tag was missing.