### PR TITLE
aws-lc tests

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -81,16 +81,6 @@ RUN curl -sSL https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VE
     chmod +x /usr/local/bin/sccache && \
     rm -rf sccache-v${SCCACHE_VER}-*-unknown-linux-musl
 
-# Build aws-lc (crypto lib used by rustls)
-RUN curl -sSL https://github.com/aws/aws-lc/archive/refs/tags/v${AWS_LC_VER}.tar.gz | tar xz
-RUN mkdir aws-lc-build && cd aws-lc-build && \
-    cmake -GNinja \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_OSX_ARCHITECTURES=aarch64 \
-        -DCMAKE_INSTALL_PREFIX=/musl \
-        ../aws-lc-${AWS_LC_VER} && \
-    ninja-build install
-
 # Set up a prefix for musl build libraries, make the linker's job of finding them easier
 # Primarily for the benefit of postgres.
 # Lastly, link some linux-headers for openssl 1.1 (not used herein)
@@ -99,6 +89,21 @@ RUN mkdir $PREFIX && \
     ln -s /usr/include/aarch64-linux-gnu/asm /usr/include/aarch64-linux-musl/asm && \
     ln -s /usr/include/asm-generic /usr/include/aarch64-linux-musl/asm-generic && \
     ln -s /usr/include/linux /usr/include/aarch64-linux-musl/linux
+
+
+# Build aws-lc (crypto lib used by rustls)
+#RUN curl -sSL https://github.com/aws/aws-lc/archive/refs/tags/v${AWS_LC_VER}.tar.gz | tar xz
+#RUN dpkg-query -L musl-tools && dpkg-query -L musl-dev && false
+#RUN mkdir aws-lc-build && cd aws-lc-build && \
+#    cmake -GNinja \
+#        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#        -DCMAKE_INSTALL_PREFIX=$PREFIX \
+#        -DBUILD_TESTING=OFF \
+#        -DBUILD_LIBSSL=OFF \
+#        -DBUILD_TOOL=OFF \
+#        -DCMAKE_OSX_ARCHITECTURES=aarch64 \
+#        ../aws-lc-${AWS_LC_VER} && \
+#    ninja install
 
 # Build zlib (used in openssl and pq)
 RUN curl -sSL https://zlib.net/zlib-$ZLIB_VER.tar.gz | tar xz && \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -21,8 +21,6 @@ RUN apt-get update && apt-get install -y \
   openssh-client \
   make \
   cmake \
-  ninja-build \
-  golang-go \
   g++ \
   curl \
   pkgconf \
@@ -56,7 +54,6 @@ RUN chmod a+X /root
 # Convenience list of versions and variables for compilation later on
 # This helps continuing manually if anything breaks.
 ENV SSL_VER="1.1.1w" \
-    AWS_LC_VER="1.46.1" \
     ZLIB_VER="1.3.1" \
     PQ_VER="11.12" \
     SQLITE_VER="3490100" \
@@ -89,21 +86,6 @@ RUN mkdir $PREFIX && \
     ln -s /usr/include/aarch64-linux-gnu/asm /usr/include/aarch64-linux-musl/asm && \
     ln -s /usr/include/asm-generic /usr/include/aarch64-linux-musl/asm-generic && \
     ln -s /usr/include/linux /usr/include/aarch64-linux-musl/linux
-
-
-# Build aws-lc (crypto lib used by rustls)
-#RUN curl -sSL https://github.com/aws/aws-lc/archive/refs/tags/v${AWS_LC_VER}.tar.gz | tar xz
-#RUN dpkg-query -L musl-tools && dpkg-query -L musl-dev && false
-#RUN mkdir aws-lc-build && cd aws-lc-build && \
-#    cmake -GNinja \
-#        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-#        -DCMAKE_INSTALL_PREFIX=$PREFIX \
-#        -DBUILD_TESTING=OFF \
-#        -DBUILD_LIBSSL=OFF \
-#        -DBUILD_TOOL=OFF \
-#        -DCMAKE_OSX_ARCHITECTURES=aarch64 \
-#        ../aws-lc-${AWS_LC_VER} && \
-#    ninja install
 
 # Build zlib (used in openssl and pq)
 RUN curl -sSL https://zlib.net/zlib-$ZLIB_VER.tar.gz | tar xz && \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -21,6 +21,8 @@ RUN apt-get update && apt-get install -y \
   openssh-client \
   make \
   cmake \
+  ninja-build \
+  golang-go \
   g++ \
   curl \
   pkgconf \
@@ -54,6 +56,7 @@ RUN chmod a+X /root
 # Convenience list of versions and variables for compilation later on
 # This helps continuing manually if anything breaks.
 ENV SSL_VER="1.1.1w" \
+    AWS_LC_VER="1.46.1" \
     ZLIB_VER="1.3.1" \
     PQ_VER="11.12" \
     SQLITE_VER="3490100" \
@@ -77,6 +80,16 @@ RUN curl -sSL https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VE
     mv sccache-v${SCCACHE_VER}-*-unknown-linux-musl/sccache /usr/local/bin/ && \
     chmod +x /usr/local/bin/sccache && \
     rm -rf sccache-v${SCCACHE_VER}-*-unknown-linux-musl
+
+# Build aws-lc (crypto lib used by rustls)
+RUN curl -sSL https://github.com/aws/aws-lc/archive/refs/tags/v${AWS_LC_VER}.tar.gz | tar xz
+RUN mkdir aws-lc-build && cd aws-lc-build && \
+    cmake -GNinja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_OSX_ARCHITECTURES=aarch64 \
+        -DCMAKE_INSTALL_PREFIX=/musl \
+        ../aws-lc-${AWS_LC_VER} && \
+    ninja-build install
 
 # Set up a prefix for musl build libraries, make the linker's job of finding them easier
 # Primarily for the benefit of postgres.

--- a/test/rustlscrate/Cargo.toml
+++ b/test/rustlscrate/Cargo.toml
@@ -5,7 +5,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hyper = { version = "0.14.18", features = ["client"] }
-hyper-rustls = "0.23.0"
-rustls = "0.22"
-tokio = { version = "1.18.2", features = ["rt-multi-thread", "macros"] }
+http-body-util = "0.1.2"
+hyper = { version = "1.6.0", features = ["client"] }
+hyper-rustls = "0.27.5"
+hyper-util = "0.1.10"
+rustls = "0.23"
+tokio = { version = "1.43.0", features = ["rt-multi-thread", "macros"] }

--- a/test/rustlscrate/src/main.rs
+++ b/test/rustlscrate/src/main.rs
@@ -1,15 +1,20 @@
-use hyper::{Body, Client, StatusCode, Uri};
+use http_body_util::Empty;
+use hyper::body::Bytes;
+use hyper::http::StatusCode;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
 
 #[tokio::main]
 async fn main() {
     let url = ("https://hyper.rs").parse().unwrap();
     let https = hyper_rustls::HttpsConnectorBuilder::new()
         .with_native_roots()
+        .expect("no native root CA certificates found")
         .https_only()
         .enable_http1()
         .build();
 
-    let client: Client<_, hyper::Body> = Client::builder().build(https);
+    let client: Client<_, Empty<Bytes>> = Client::builder(TokioExecutor::new()).build(https);
 
     let res = client.get(url).await.unwrap();
     assert_eq!(res.status(), StatusCode::OK);


### PR DESCRIPTION
To see if we can build rustls deps with aws-lc
closes #141 

## We don't need to do anything.
Updating tests is enough. Example taken from [hyper-rustls](https://docs.rs/hyper-rustls/latest/hyper_rustls/)

It works out of the box because the `aws-lc-sys` crate just works and passes tests provided i actually update rustls in the test suite.

## Notes on Compiling

pointless log of my exploration of actually compiling it.


<details><summary>building it from docker</summary>
<p>
avoided by not doing any linking in the build (turning off tool, libssl build and test builds)

for posterity the following invocation does at least compile in the image

```dockerfile
# ADD: apt-get install -y ninja-build golang-go
# THEN DL + COMPILE:
RUN curl -sSL https://github.com/aws/aws-lc/archive/refs/tags/v${AWS_LC_VER}.tar.gz | tar xz && \
    mkdir aws-lc-build && cd aws-lc-build && \
    cmake -GNinja \
        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
        -DCMAKE_INSTALL_PREFIX=$PREFIX \
        -DBUILD_TESTING=OFF \
        -DBUILD_LIBSSL=OFF \
        -DBUILD_TOOL=OFF \
        -DCMAKE_OSX_ARCHITECTURES=aarch64 \
        ../aws-lc-${AWS_LC_VER} && \
    ninja install
```

</p></details>


<details><summary>/bin/sh: 1: ninja-build: not found despite apt installing ninja-build</summary>
<p>
is there under different name:

```sh
 > [ 8/15] RUN dpkg-query -L ninja-build && false:
0.085 /.
0.085 /usr
0.085 /usr/bin
0.085 /usr/bin/ninja
0.085 /usr/share
0.085 /usr/share/bash-completion
0.085 /usr/share/bash-completion/completions
0.085 /usr/share/bash-completion/completions/ninja
0.085 /usr/share/doc
0.085 /usr/share/doc/ninja-build
0.085 /usr/share/doc/ninja-build/changelog.Debian.gz
0.085 /usr/share/doc/ninja-build/copyright
0.085 /usr/share/doc/ninja-build/manual.html
0.085 /usr/share/doc-base
0.085 /usr/share/doc-base/ninja-build.ninja-build-manual
0.085 /usr/share/emacs
0.085 /usr/share/emacs/site-lisp
0.085 /usr/share/emacs/site-lisp/ninja-mode.el
0.085 /usr/share/man
0.085 /usr/share/man/man1
0.085 /usr/share/man/man1/ninja.1.gz
0.085 /usr/share/vim
0.085 /usr/share/vim/addons
0.085 /usr/share/vim/addons/syntax
0.085 /usr/share/vim/addons/syntax/ninja.vim
0.085 /usr/share/zsh
0.085 /usr/share/zsh/vendor-completions
0.085 /usr/share/zsh/vendor-completions/_ninja
```

using `ninja` over `ninja-build`.
</p>
</details>

<details><summary>/usr/bin/ld: cannot find -lgcc_s: No such file or directory</summary>
<p>
avoided by not doing any linking in the build (turning off tool, libssl build and test builds)

</p>
</details>
<details><summary>dropping go dep</summary>
<p>

seems to be a build time dep that we can drop according to

https://github.com/aws/aws-lc/blob/dc3b44be65ac29fc1999ab2aad2d06c64f7525b6/BUILDING.md?plain=1#L217-L225

didn't try.

</p>
</details>

