### PR TITLE
Bump docker/build-push-action from 5 to 6

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Build nightly image
       id: build
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         platforms: ${{ matrix.platform }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Build stable image
       id: build
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         platforms: ${{ matrix.platform }}


### PR DESCRIPTION
closes https://github.com/clux/muslrust/pull/148

should give a new build summary in the action. EDIT: [yes](https://github.com/clux/muslrust/actions/runs/15163358357/attempts/1#summary-42634661189)