### PR TITLE
chore: `Dockerfile` use HereDoc syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM ubuntu:noble
+SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
+
 LABEL maintainer="Eirik Albrigtsen <sszynrae@gmail.com>"
 LABEL org.opencontainers.image.create="$(date --utc --iso-8601=seconds)"
 LABEL org.opencontainers.image.documentation="https://github.com/clux/muslrust"
@@ -15,91 +17,113 @@ LABEL org.opencontainers.image.description="Docker environment for building musl
 # - file - needed by rustup.sh install
 # - automake autoconf libtool - support crates building C deps as part cargo build
 # NB: does not include cmake atm
-RUN apt-get update && apt-get install -y \
-  musl-dev \
-  musl-tools \
-  file \
-  git \
-  openssh-client \
-  make \
-  cmake \
-  g++ \
-  curl \
-  pkgconf \
-  ca-certificates \
-  automake \
-  autoconf \
-  libtool \
-  libprotobuf-dev \
-  unzip \
-  --no-install-recommends && \
+RUN <<HEREDOC
+  apt-get update
+  apt-get install --no-install-recommends -y \
+      musl-dev \
+      musl-tools \
+      file \
+      git \
+      openssh-client \
+      make \
+      cmake \
+      g++ \
+      curl \
+      pkgconf \
+      ca-certificates \
+      automake \
+      autoconf \
+      libtool \
+      libprotobuf-dev \
+      unzip
+
   rm -rf /var/lib/apt/lists/*
+HEREDOC
 
 # Common arg for arch used in urls and triples
 ARG AARCH
 # Install rust using rustup
 ARG CHANNEL
-ENV RUSTUP_VER="1.28.2" \
-    RUST_ARCH="${AARCH}-unknown-linux-gnu" \
-    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
-RUN curl "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/${RUST_ARCH}/rustup-init" -o rustup-init && \
-    chmod +x rustup-init && \
-    ./rustup-init -y --default-toolchain ${CHANNEL} --profile minimal --no-modify-path && \
-    rm rustup-init && \
-    ~/.cargo/bin/rustup target add ${AARCH}-unknown-linux-musl
+ARG RUSTUP_VER="1.28.2"
+ARG RUST_ARCH="${AARCH}-unknown-linux-gnu"
+RUN <<HEREDOC
+    curl -fsSL -o rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/${RUST_ARCH}/rustup-init"
+    chmod +x rustup-init
+    ./rustup-init -y --default-toolchain "${CHANNEL}" --profile minimal --no-modify-path
+    rm rustup-init
+    ~/.cargo/bin/rustup target add "${AARCH}-unknown-linux-musl"
+HEREDOC
 
 # Allow non-root access to cargo
 RUN chmod a+X /root
 
 # Convenience list of versions and variables for compilation later on
 # This helps continuing manually if anything breaks.
-ENV ZLIB_VER="1.3.1" \
-    SQLITE_VER="3490200" \
-    PROTOBUF_VER="31.0" \
-    SCCACHE_VER="0.10.0" \
-    CC=musl-gcc \
+ENV CC=musl-gcc \
     PREFIX=/musl \
-    PATH=/usr/local/bin:/root/.cargo/bin:$PATH \
+    PATH=/usr/local/bin:/root/.cargo/bin:${PATH} \
     PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
-    LD_LIBRARY_PATH=$PREFIX
+    LD_LIBRARY_PATH=${PREFIX}
 
-# Install a more recent release of protoc (protobuf-compiler in jammy is 4 years old and misses some features)
-RUN cd /tmp && \
-    curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/protoc-${PROTOBUF_VER}-linux-$([ "$AARCH" = "aarch64" ] && echo "aarch_64" || echo "$AARCH").zip -o protoc.zip && \
-    unzip protoc.zip && \
-    cp bin/protoc /usr/bin/protoc && \
+# Install a more recent release of protoc (protobuf-compiler in Ubuntu Noble is v21.12 from Dec 2022)
+ARG PROTOBUF_VER="31.0"
+RUN <<HEREDOC
+    ASSET_NAME="protoc-${PROTOBUF_VER}-linux-$([ "${AARCH}" = "aarch64" ] && echo "aarch_64" || echo "{$AARCH}")"
+    curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/${ASSET_NAME}.zip"
+
+    cd /tmp && unzip protoc.zip
+    cp bin/protoc /usr/bin/protoc
     rm -rf *
+HEREDOC
 
 # Install prebuilt sccache based on platform
-RUN curl -sSL https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-${AARCH}-unknown-linux-musl.tar.gz | tar xz && \
-    mv sccache-v${SCCACHE_VER}-*-unknown-linux-musl/sccache /usr/local/bin/ && \
-    chmod +x /usr/local/bin/sccache && \
+ARG SCCACHE_VER="0.10.0"
+RUN <<HEREDOC
+    ASSET_NAME="sccache-v${SCCACHE_VER}-${AARCH}-unknown-linux-musl"
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/${ASSET_NAME}.tar.gz" | tar -xz
+    mv "${ASSET_NAME}/sccache" /usr/local/bin/
+    chmod +x /usr/local/bin/sccache
     rm -rf sccache-v${SCCACHE_VER}-*-unknown-linux-musl
+HEREDOC
 
 # Build zlib
-RUN curl -sSL https://zlib.net/zlib-$ZLIB_VER.tar.gz | tar xz && \
-    cd zlib-$ZLIB_VER && \
-    CC="musl-gcc -fPIC -pie" LDFLAGS="-L$PREFIX/lib" CFLAGS="-I$PREFIX/include" ./configure --static --prefix=$PREFIX && \
-    make -j$(nproc) && make install && \
-    cd .. && rm -rf zlib-$ZLIB_VER
+ARG ZLIB_VER="1.3.1"
+RUN <<HEREDOC
+    curl -fsSL "https://zlib.net/zlib-${ZLIB_VER}.tar.gz" | tar -xz
+    cd "zlib-${ZLIB_VER}"
+
+    CC="musl-gcc -fPIC -pie"
+    CFLAGS="-I${PREFIX}/include"
+    LDFLAGS="-L${PREFIX}/lib"
+    ./configure --static --prefix="${PREFIX}"
+    make -j$(nproc) && make install
+
+    cd .. && rm -rf "zlib-${ZLIB_VER}"
+HEREDOC
 
 # Build libsqlite3 using same configuration as the alpine linux main/sqlite package
-RUN curl -sSL https://www.sqlite.org/2025/sqlite-autoconf-$SQLITE_VER.tar.gz | tar xz && \
-    cd sqlite-autoconf-$SQLITE_VER && \
-    CFLAGS="-DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_SECURE_DELETE -DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_ENABLE_RTREE -DSQLITE_USE_URI -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_ENABLE_JSON1" \
-    CC="musl-gcc -fPIC -pie" \
-    ./configure --prefix=$PREFIX --host=x86_64-unknown-linux-musl --enable-threadsafe --disable-shared && \
-    make && make install && \
-    cd .. && rm -rf sqlite-autoconf-$SQLITE_VER
+ARG SQLITE_VER="3490200"
+RUN <<HEREDOC
+    curl -fsSL "https://www.sqlite.org/2025/sqlite-autoconf-${SQLITE_VER}.tar.gz" | tar -xz
+    cd "sqlite-autoconf-${SQLITE_VER}"
 
-ENV PATH=/root/.cargo/bin:$PREFIX/bin:$PATH \
+    CC="musl-gcc -fPIC -pie"
+    CFLAGS="-DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_SECURE_DELETE -DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_ENABLE_RTREE -DSQLITE_USE_URI -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_ENABLE_JSON1"
+    ./configure --prefix="${PREFIX}" --host=x86_64-unknown-linux-musl --enable-threadsafe --disable-shared
+    make && make install
+
+    cd .. && rm -rf "sqlite-autoconf-${SQLITE_VER}"
+HEREDOC
+
+ENV PATH=/root/.cargo/bin:${PREFIX}/bin:${PATH} \
     RUSTUP_HOME=/root/.rustup \
     CARGO_BUILD_TARGET=${AARCH}-unknown-linux-musl \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld -Ctarget-feature=+crt-static" \
     PKG_CONFIG_ALLOW_CROSS=true \
     PKG_CONFIG_ALL_STATIC=true \
-    PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig \
+    PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig \
     PG_CONFIG_X86_64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
     PG_CONFIG_AARCH64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
     # Rust libz-sys support

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,108 +18,120 @@ LABEL org.opencontainers.image.description="Docker environment for building musl
 # - automake autoconf libtool - support crates building C deps as part cargo build
 # NB: does not include cmake atm
 RUN <<HEREDOC
-  apt-get update
-  apt-get install --no-install-recommends -y \
-      musl-dev \
-      musl-tools \
-      file \
-      git \
-      openssh-client \
-      make \
-      cmake \
-      g++ \
-      curl \
-      pkgconf \
-      ca-certificates \
-      automake \
-      autoconf \
-      libtool \
-      libprotobuf-dev \
-      unzip
+    apt-get update
+    apt-get install --no-install-recommends -y \
+        musl-dev \
+        musl-tools \
+        file \
+        git \
+        openssh-client \
+        make \
+        cmake \
+        g++ \
+        curl \
+        pkgconf \
+        ca-certificates \
+        automake \
+        autoconf \
+        libtool \
+        libprotobuf-dev \
+        unzip
 
-  rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 HEREDOC
 
 # Common arg for arch used in urls and triples
 ARG AARCH
+
 # Install rust using rustup
 ARG CHANNEL
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-
+# Use specific version of Rustup:
+# https://github.com/clux/muslrust/pull/63
 ARG RUSTUP_VER="1.28.2"
-ARG RUST_ARCH="${AARCH}-unknown-linux-gnu"
+# Better support for running container user as non-root:
+# https://github.com/clux/muslrust/pull/101
+# Uses `--no-modify-path` with PATH update + chmod on `/root` for access
+ENV CARGO_BUILD_TARGET=${AARCH}-unknown-linux-musl
+ENV RUSTUP_HOME=/root/.rustup
+ENV PATH=/root/.cargo/bin:${PATH}
 RUN <<HEREDOC
+    # Allow non-root access to cargo/rustup:
+    chmod a+X /root
+
+    RUST_ARCH="${AARCH}-unknown-linux-gnu"
     curl -fsSL -o rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VER}/${RUST_ARCH}/rustup-init"
     chmod +x rustup-init
-    ./rustup-init -y --default-toolchain "${CHANNEL}" --profile minimal --no-modify-path
+
+    ./rustup-init -y \
+      --default-toolchain "${CHANNEL}" \
+      --profile minimal \
+      --no-modify-path \
+      --target "${AARCH}-unknown-linux-musl"
+
     rm rustup-init
-    ~/.cargo/bin/rustup target add "${AARCH}-unknown-linux-musl"
 HEREDOC
 
-# Allow non-root access to cargo
-RUN chmod a+X /root
-
-# Convenience list of versions and variables for compilation later on
+# Convenience list of variables for later compilation stages.
 # This helps continuing manually if anything breaks.
 ENV CC=musl-gcc \
     PREFIX=/musl \
-    PATH=/usr/local/bin:/root/.cargo/bin:${PATH} \
-    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
-    LD_LIBRARY_PATH=${PREFIX}
+    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
-# Install a more recent release of protoc (protobuf-compiler in Ubuntu Noble is v21.12 from Dec 2022)
+# Install a more recent release of protoc
+# NOTE: `protobuf-compiler` in Ubuntu Noble is v21.12 (Dec 2022):
+# https://launchpad.net/ubuntu/noble/+package/protobuf-compiler
 ARG PROTOBUF_VER="31.0"
 RUN <<HEREDOC
     ASSET_NAME="protoc-${PROTOBUF_VER}-linux-$([ "${AARCH}" = "aarch64" ] && echo "aarch_64" || echo "{$AARCH}")"
-    curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/${ASSET_NAME}.zip"
+    curl -fsSL -o protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VER}/${ASSET_NAME}.zip"
 
-    cd /tmp && unzip protoc.zip
-    cp bin/protoc /usr/bin/protoc
-    rm -rf *
+    unzip -j -d /usr/local/bin protoc.zip bin/protoc
+    rm -rf protoc.zip
 HEREDOC
 
 # Install prebuilt sccache based on platform
 ARG SCCACHE_VER="0.10.0"
 RUN <<HEREDOC
     ASSET_NAME="sccache-v${SCCACHE_VER}-${AARCH}-unknown-linux-musl"
-    curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/${ASSET_NAME}.tar.gz" | tar -xz
-    mv "${ASSET_NAME}/sccache" /usr/local/bin/
-    chmod +x /usr/local/bin/sccache
-    rm -rf sccache-v${SCCACHE_VER}-*-unknown-linux-musl
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/${ASSET_NAME}.tar.gz" \
+      | tar -xz -C /usr/local/bin --strip-components=1 --no-same-owner "${ASSET_NAME}/sccache"
 HEREDOC
 
 # Build zlib
+FROM base AS build-zlib
 ARG ZLIB_VER="1.3.1"
+WORKDIR /src/zlib
 RUN <<HEREDOC
-    curl -fsSL "https://zlib.net/zlib-${ZLIB_VER}.tar.gz" | tar -xz
-    cd "zlib-${ZLIB_VER}"
+    curl -fsSL "https://zlib.net/zlib-${ZLIB_VER}.tar.gz" | tar -xz --strip-components=1
 
-    CC="musl-gcc -fPIC -pie"
-    CFLAGS="-I${PREFIX}/include"
-    LDFLAGS="-L${PREFIX}/lib"
+    export CC="musl-gcc -fPIC -pie"
+    export CFLAGS="-I${PREFIX}/include"
+    export LDFLAGS="-L${PREFIX}/lib"
+
     ./configure --static --prefix="${PREFIX}"
     make -j$(nproc) && make install
-
-    cd .. && rm -rf "zlib-${ZLIB_VER}"
 HEREDOC
 
 # Build libsqlite3 using same configuration as the alpine linux main/sqlite package
+FROM base AS build-sqlite
 ARG SQLITE_VER="3490200"
+WORKDIR /src/sqlite
 RUN <<HEREDOC
-    curl -fsSL "https://www.sqlite.org/2025/sqlite-autoconf-${SQLITE_VER}.tar.gz" | tar -xz
-    cd "sqlite-autoconf-${SQLITE_VER}"
+    curl -fsSL "https://www.sqlite.org/2025/sqlite-autoconf-${SQLITE_VER}.tar.gz" | tar -xz --strip-components=1
 
-    CC="musl-gcc -fPIC -pie"
-    CFLAGS="-DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_SECURE_DELETE -DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_ENABLE_RTREE -DSQLITE_USE_URI -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_ENABLE_JSON1"
+    export CC="musl-gcc -fPIC -pie"
+    export CFLAGS="-DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_SECURE_DELETE -DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_ENABLE_RTREE -DSQLITE_USE_URI -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_ENABLE_JSON1"
+
     ./configure --prefix="${PREFIX}" --host=x86_64-unknown-linux-musl --enable-threadsafe --disable-shared
     make && make install
-
-    cd .. && rm -rf "sqlite-autoconf-${SQLITE_VER}"
 HEREDOC
 
-ENV PATH=/root/.cargo/bin:${PREFIX}/bin:${PATH} \
-    RUSTUP_HOME=/root/.rustup \
-    CARGO_BUILD_TARGET=${AARCH}-unknown-linux-musl \
+FROM base AS release
+COPY --link --from=build-zlib ${PREFIX} ${PREFIX}
+COPY --link --from=build-sqlite ${PREFIX} ${PREFIX}
+
+# NOTE: PATH prepends `${PREFIX}/bin` for `sqlite3`
+ENV PATH=${PREFIX}/bin:${PATH} \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld -Ctarget-feature=+crt-static" \
     PKG_CONFIG_ALLOW_CROSS=true \
     PKG_CONFIG_ALL_STATIC=true \


### PR DESCRIPTION
This PR updates the `Dockerfile` to use [HereDoc syntax](https://docs.docker.com/reference/dockerfile/#here-documents), as suggested [here](https://github.com/clux/muslrust/issues/139#issuecomment-2833954251). This allows for `RUN` statements to drop the `&& \` noise and be easier to grok like a regular shell script.

If you review the first commit that should be fairly straight-forward. I've since noticed other portions of the `Dockerfile` that could do with some maintenance, but lack time to stagger PRs for each individually, the bulk of those are in the follow-up commits (_might be easier to review separately if you rely on a diff_).

---

**Additionally:**
- `ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse` can be dropped as this is the [default since Rust 1.70.0](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0/#sparse-by-default-for-crates-io).
- Variables use `${VAR_NAME}` instead of `$VARNAME`. I've replaced some `ENV` with `ARG` since they're only intended for build-time usage and located them by each associated `RUN` so that adjusting these won't invalidate all layers.
- In your [recent PR](https://github.com/clux/muslrust/pull/155) you added some additional `LABEL` (_the existing `maintainer` label is discouraged btw_), one of these you attempt to set the value with a shell command, but these are string values for assignment. If you assumed you could run a subshell because of `${VAR_NAME}` usage, that's not a shell ENV but an equivalent feature supported by the `Dockerfile` format to reference and use `ENV` / `ARG`. Thus this value literally stores that as a string:

    ```Dockerfile
    LABEL org.opencontainers.image.create="$(date --utc --iso-8601=seconds)"
    ```
- Likewise, no need for this when you have `--target` option for `rustup-init`:
    ```bash
    ~/.cargo/bin/rustup target add "${AARCH}-unknown-linux-musl"
    ```
- `SHELL` is defined early on to change the default `/bin/sh` used by `RUN` instructions.
  - This will ensure a build fails early and persists a failed command exit status when a pipe is involved (_instead of relying on the exit code from the command after the pipe_). It should help with troubleshooting builds if something goes awry.
  - `/bin/sh` in Debian/Ubuntu symlinks to `/usr/bin/dash`, I've chosen `/usr/bin/bash` here which is usually what is expected. On Fedora `/bin/sh` symlinks to `/usr/bin/bash` and Alpine to `/usr/bin/ash`
- I've removed the comment for `protoc` version in Jammy having missing features.
  - https://github.com/clux/muslrust/pull/127 which introduced the comment was related to version bumping to 1.25 instead of [3.12.4 from Jammy](https://launchpad.net/ubuntu/jammy/+package/protobuf-compiler) ([GH release](https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.4), July 2020), while [Noble offers 3.21.12](https://launchpad.net/ubuntu/noble/+package/protobuf-compiler) ([GH Release](https://github.com/protocolbuffers/protobuf/releases/tag/v21.12), Dec 2022).
  - As you're now on 3.31.0 from GH, it's up to you if a newer version is relevant or if you'd use dated packages like anything else with your choice of base distro. Fedora 42 (released April 2025) is usually more up to date with packages but their equivalent package `protobuf-compiler` is [3.19.6](https://github.com/protocolbuffers/protobuf/releases/tag/v3.19.6) (Sep 2022) 🤷‍♂️
- `PATH` was set twice, while referencing the previous set PATH which set duplicate paths. The final PATH value became:

    ```
    /root/.cargo/bin:/musl/bin:/usr/local/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
    ```

    I've resolved that. You also switched from Debian to Ubuntu in 2016, where you [prepended `/usr/local/bin` to PATH](https://github.com/clux/muslrust/commit/67549c9d84fc3f51229e79b99b8519018c32fcab), but that should be unnecessary as it's already in the PATH.
- `PREFIX` is set in the same ENV instruction as `LD_LIBRARY_PATH` which references it. Thus PREFIX is empty and this likely fails to do what was intended.
  - You'd need to set `ENV PREFIX` separately before an `ENV LD_LIBRARY_PATH`.
  - However it's very bad practice to use `ENV LD_LIBRARY_PATH`, you should prefer to use that explicitly as a prefix to commands rather than a global env.
  - I traced it's addition down to [this commit](https://github.com/clux/muslrust/commit/b93f1db55f9a7ef5d36d52d3bfd523461bfba6f2#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R51-R55) (Oct 2017). The associated PR and referenced issue the PR fixes makes no mention of `LD_LIBRARY_PATH` being useful, and given that it's been empty since then I've removed that too.
- In the 2nd commit `zlib` + `sqlite` are now handled in separate stages. I also put rustup into it's own stage in the third commit and shifted your labels to the end (_while switching the maintainer label for standardized authors one_). This has a breaking change where I migrated cargo + rustup to `/opt` instead of storing them in `/root`. You don't need to give access to `/root` home folder this way, but if any one used the image while cache mounting or similar with the `/root` location hard-coded then this might be an unexpected change for them.