### PR TITLE
ci: Refactor `stable.yml`

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       CONTINUE_BUILD: ${{ steps.check-stable-tag.outputs.CONTINUE_BUILD }}
     runs-on: 'ubuntu-latest'
+    steps:
       - uses: actions/checkout@v4
       - name: 'Check if we need a new stable'
         id: check-stable-tag
@@ -60,11 +61,6 @@ jobs:
         with:
           username: clux
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta
@@ -178,11 +174,21 @@ jobs:
           RUST_CHANNEL=$(cat /tmp/tags/rust-channel)
           RUST_VER=$(cat /tmp/tags/rust-ver)
 
-          for tag in ${RUST_CHANNEL} ${RUST_CHANNEL}-${RUST_DATE} ${RUST_VER}-${RUST_CHANNEL} ${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}; do
-            docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:$tag \
-              ${{ env.REGISTRY_IMAGE }}:amd64-${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE} \
-              ${{ env.REGISTRY_IMAGE }}:arm64-${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}
-            done
+          # The two already published image tags to associate additional tags to:
+          AMD64="${{ env.REGISTRY_IMAGE }}:amd64-${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}"
+          ARM64="${{ env.REGISTRY_IMAGE }}:arm64-${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}"
+
+          EXTRA_TAGS=(
+            "${RUST_CHANNEL}"
+            "${RUST_CHANNEL}-${RUST_DATE}"
+            "${RUST_VER}-${RUST_CHANNEL}"
+            "${RUST_VER}-${RUST_CHANNEL}-${RUST_DATE}"
+          )
+
+          # Assign each tag to the two source image tags:
+          for TAG in "${EXTRA_TAGS[@]}"; do
+            docker buildx imagetools create --tag "${{ env.REGISTRY_IMAGE }}:${TAG}" "${AMD64}" "${ARM64}"
+          done
 
       - name: Inspect image
         run: |

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -17,8 +17,28 @@ env:
   REGISTRY_IMAGE: clux/muslrust
 
 jobs:
+  check-stable:
+    name: 'Check if workflow should continue'
+    outputs:
+      CONTINUE_BUILD: ${{ steps.check-stable-tag.outputs.CONTINUE_BUILD }}
+    runs-on: 'ubuntu-latest'
+      - uses: actions/checkout@v4
+      - name: 'Check if we need a new stable'
+        id: check-stable-tag
+        shell: bash
+        run: |
+          pip3 install --user toml
+          if python3 check_stable.py; then
+            echo 'Stable tag missing; running all build steps'
+            echo 'CONTINUE_BUILD=YES' >> "${GITHUB_OUTPUT}"
+          else
+            echo 'Stable tag found; skipping all build steps'
+          fi
+
   build:
     name: 'Stable Build'
+    needs: [check-stable]
+    if: ${{ needs.check-stable.outputs.CONTINUE_BUILD == 'YES' }}
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
@@ -40,18 +60,6 @@ jobs:
         with:
           username: clux
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Check if we need a new stable
-        id: stablecheck
-        shell: bash
-        run: |
-          pip3 install --user toml
-          if python3 check_stable.py; then
-            echo "Stable tag missing; running all build steps"
-            echo "BUILD=YES" >> $GITHUB_OUTPUT
-          else
-            echo "Stable tag found; skipping all build steps"
-          fi
 
       - name: Prepare
         run: |
@@ -82,10 +90,8 @@ jobs:
           tags: rustmusl-temp
           build-args: |
             CHANNEL=stable
-        if: ${{ steps.stablecheck.outputs.BUILD }}
 
       - name: Run tests
-        if: ${{ steps.stablecheck.outputs.BUILD }}
         shell: bash
         run: |
           docker buildx build --platform ${{ matrix.platform }} --output type=docker -t test-runner - < Dockerfile.test-runner
@@ -98,7 +104,6 @@ jobs:
       # only identifiable by their digest and it appears docker does not let us select an image that way.
       # Not the most elegant, but it works.
       - name: Store tag info
-        if: ${{ steps.stablecheck.outputs.BUILD }}
         shell: bash
         run: |
           mkdir -p /tmp/tags
@@ -111,7 +116,6 @@ jobs:
           echo $RUST_VER > /tmp/tags/rust-ver
 
       - name: Tag and push
-        if: ${{ steps.stablecheck.outputs.BUILD }}
         shell: bash
         run: |
           RUST_DATE=$(cat /tmp/tags/rust-date)
@@ -125,7 +129,6 @@ jobs:
 
       # TODO: want to do this, but need digest, which might not be trivial to get outside build-push-action
       # - name: Attest docker.io
-      #   if: ${{ steps.stablecheck.outputs.BUILD }}
       #   uses: actions/attest-build-provenance@v2.3.0
       #   with:
       #     subject-name: docker.io/${{ env.REGISTRY_IMAGE }}
@@ -133,7 +136,6 @@ jobs:
       #     push-to-registry: true
 
       - name: Upload tags
-        if: ${{ steps.stablecheck.outputs.BUILD }}
         uses: actions/upload-artifact@v4
         with:
           name: tags-${{matrix.arch}}
@@ -148,21 +150,7 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v4
-      - name: Check if we need a new stable
-        id: stablecheck
-        shell: bash
-        run: |
-          pip3 install --user toml
-          if python3 check_stable.py; then
-            echo "Stable tag missing; running all build steps"
-            echo "BUILD=YES" >> $GITHUB_OUTPUT
-          else
-            echo "Stable tag found; skipping all build steps"
-          fi
-
       - name: Download tags
-        if: ${{ steps.stablecheck.outputs.BUILD }}
         uses: actions/download-artifact@v4
         with:
           path: /tmp/tags
@@ -185,7 +173,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create manifest list and push multi-platform images
-        if: ${{ steps.stablecheck.outputs.BUILD }}
         run: |
           RUST_DATE=$(cat /tmp/tags/rust-date)
           RUST_CHANNEL=$(cat /tmp/tags/rust-channel)
@@ -198,6 +185,5 @@ jobs:
             done
 
       - name: Inspect image
-        if: ${{ steps.stablecheck.outputs.BUILD }}
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:latest

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -169,6 +169,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create manifest list and push multi-platform images
+        shell: bash
         run: |
           RUST_DATE=$(cat /tmp/tags/rust-date)
           RUST_CHANNEL=$(cat /tmp/tags/rust-channel)


### PR DESCRIPTION
For the most part this just pulls the stable check script to the start of the workflow to bail early instead of littering the same conditional in many steps that follow (including build and tests).

The other big change is the final step to assign more tags to the image when it is published. The logic should be the same, I've just rearranged it to be a bit nicer to grok.

**NOTE:** Given that you've centralized to a single `Dockerfile` now, and it can be built successfully with multiple platforms (without a build arg for the arch necessary), you could avoid all this dance with the tag management.
- Only the extraction of the `RUST_VER` is a little tricky, but you should be able to just append that tag in a post publish step?
- You've also got the option to use the ARM64 runner for `aarch64` image builds instead of the slower QEMU process. For that you'd need to retain the merge workflow if you need to speed up the CI, otherwise it's easier with QEMU.


---

`PLATFORM_PAIR` appears unused? Introduced [here](https://github.com/clux/muslrust/commit/8781ff02ce9aeb209f69fbd4bb9e0c2198e18d2f#diff-eddaa43b142a4a5fbb9297f1e7b3c59401c1f22790df62f04954baa4370e72e9R61) as part of [this PR](https://github.com/clux/muslrust/pull/133) that introduced ARM64 platform images in Feb 2024.

Basically it turns `linux/x86_64` to `linux-x86_64`, presumably it was intended at some point to be used in part of the image tag naming?:

```bash
platform=${{ matrix.platform }}
echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
```

Removed it as it doesn't seem to be serving a purpose.

---

That [multi-arch PR](https://github.com/clux/muslrust/pull/133) also chose to associate the `latest` tag to the nightly builds for some reason which seems odd? I could switch that over to the stable workflow instead?

---

I also noticed scheduled builds at 10am (Nightly) and 12pm (Stable), no context was provided for the offset if intentional? (_introduced from [this commit](https://github.com/clux/muslrust/commit/3e6d2bd1eade5c0c2eef9f2b4bf7e17f7349384e)_)

For the most part the stable and nightly workflows are effectively identical. A good portion could be split out and shared with an input of `stable` / `nightly` to distinguish the two builds (_which the last step with adding extra tags could use to differentiate assigning `latest`.